### PR TITLE
nomicon へのリンクの修正

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -57,5 +57,5 @@ of safety and guarantees.
 
 [trpl]: https://doc.rust-lang.org/book/
 [he]: http://quotes.yourdictionary.com/author/h-p-lovecraft/172934
-[nomicon-en]: https://doc.rust-lang.org/nomicon/README.html
-[bookja]: https://github.com/imsut/rust-nomicon-ja
+[nomicon-en]: https://doc.rust-lang.org/nomicon/index.html
+[bookja]: https://github.com/rust-lang-ja/rust-nomicon-ja


### PR DESCRIPTION
原文へのリンクが切れていたので修正。

翻訳文書へのリンクは https://github.com/imsut/rust-nomicon-ja になっていて
アクセスすると https://github.com/rust-lang-ja/rust-nomicon-ja にリダイレクト
されていました。おそらく github 側がプロジェクトが移動したとき、自動でリダイレ
クトするよう配慮しているのだと思われます。
