### PR TITLE
Fix lifetime-mismatch.md

### DIFF
--- a/src/lifetime-mismatch.md
+++ b/src/lifetime-mismatch.md
@@ -109,7 +109,7 @@ This program is clearly correct according to the reference semantics we actually
 care about, but the lifetime system is too coarse-grained to handle that.
 -->
 
-このプログラムは、私たちにとって重要なリファレンスの意味的には全く正しいのですが、
+このプログラムは、私たちにとって重要な参照の意味的には全く正しいのですが、
 ライフタイムシステムはこのプログラムを処理するには粗すぎるのです。
 
 <!--

--- a/src/lifetime-mismatch.md
+++ b/src/lifetime-mismatch.md
@@ -45,12 +45,15 @@ However when we try to compile it:
 
 ```text
 <anon>:11:5: 11:8 error: cannot borrow `foo` as immutable because it is also borrowed as mutable
+(エラー: `foo`は可変で借用されているので、不変で借用できません)
 <anon>:11     foo.share();
               ^~~
 <anon>:10:16: 10:19 note: previous borrow of `foo` occurs here; the mutable borrow prevents subsequent moves, borrows, or modification of `foo` until the borrow ends
+(注釈: 以前の`foo`の借用はここで起きています。可変での借用は、その借用が終わるまで、その後のムーブや、借用、`foo`の変更を防ぎます)
 <anon>:10     let loan = foo.mutate_and_share();
                          ^~~
 <anon>:12:2: 12:2 note: previous borrow ends here
+(注釈: 以前の借用はここで終了しています)
 <anon>:8 fn main() {
 <anon>:9     let mut foo = Foo;
 <anon>:10     let loan = foo.mutate_and_share();

--- a/src/lifetime-mismatch.md
+++ b/src/lifetime-mismatch.md
@@ -32,9 +32,9 @@ would expect `foo.share()` to succeed as `foo` shouldn't be mutably borrowed.
 -->
 
 このコードはコンパイルを通ると思うかもしれません。
-`mutate_and_share` は、`foo` を一時的に変更可能に借り入れますが、
-共有リファレンスを返します。
-そうすると、`foo` は変更可能には借りられていないので、
+`mutate_and_share` は、`foo` を一時的に変更可能に借用しますが、
+共有参照を返します。
+そうすると、`foo` は変更可能には借用されていないので、
 `foo.share()` は成功すると思うでしょう。
 
 <!--


### PR DESCRIPTION
Related: https://github.com/rust-lang-ja/rust-nomicon-ja/issues/4

日本語版のThe Rust Programming Languageではエラーメッセージも訳されているので，こちらでも訳してみました．