### PR TITLE
mdBook 0.4.5でサイトを再生成（CVE-2020-26297対応）

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,6 @@
 
 
         <!-- Custom HTML head -->
-        
 
 
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type">


### PR DESCRIPTION
GitHub Actionsのジョブを実行することで、mdBookの最新版（0.4.5）で [サイト](https://doc.rust-jp.rs/rust-nomicon-ja/) を生成します。理由は、それより前のバージョンで生成したサイトの検索機能にセキュリティーの脆弱性があるためです。

脆弱性の詳細：
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26297
- https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html

ジョブの実行についてですが、現在のワークフローの設定（[`.github/workflows/rust.yaml`](https://github.com/rust-lang-ja/rust-nomicon-ja/blob/24b51e3451bae3139ad2936f1d4eb1870059e013/.github/workflows/rust.yml#L3-L6)）ですと、git pushしないとジョブが起動できないため、`docs/index.html`から空行を1行取り除いてcommitしています。

なお、ワークフローを`workflow_dispatch`イベントでも起動できるようにすると、GitHub Actionsのウェブページからの起動が可能になるようです（[ドキュメント](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow)）　が、今回のようなことは頻繁には起きなさそうなので、このpull requestではワークフローの設定変更は行いません。